### PR TITLE
refactor: use import path aliases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
-  "extends": [
-    "react-app",
-    "react-app/jest",
-    "plugin:prettier/recommended"
-  ],
+  "extends": ["react-app", "react-app/jest", "plugin:prettier/recommended"],
   "rules": {
     "no-console": "error",
     "no-eval": "error"

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,26 @@
+const path = require("path");
+
+module.exports = {
+  webpack: {
+    alias: {
+      "@components": path.resolve(__dirname, "src/components"),
+      "@hooks": path.resolve(__dirname, "src/hooks"),
+      "@type": path.resolve(__dirname, "src/types"),
+      "@styles": path.resolve(__dirname, "src/styles"),
+      "@util": path.resolve(__dirname, "src/util"),
+    },
+  },
+  jest: {
+    configure: (jestConfig) => {
+      jestConfig.moduleNameMapper = {
+        ...jestConfig.moduleNameMapper,
+        "^@components(.*)$": "<rootDir>/src/components$1",
+        "^@hooks(.*)$": "<rootDir>/src/hooks$1",
+        "^@type(.*)$": "<rootDir>/src/types$1",
+        "^@styles(.*)$": "<rootDir>/src/styles$1",
+        "^@util(.*)$": "<rootDir>/src/util$1",
+      };
+      return jestConfig;
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "weather-app",
   "version": "0.1.1",
   "private": true,
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
@@ -24,10 +27,10 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --reporters=default --reporters=jest-junit",
-    "eject": "react-scripts eject",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test --watchAll=true",
+    "eject": "craco eject",
     "prepare": "husky install",
     "lint-staged": "lint-staged"
   },
@@ -48,6 +51,8 @@
     "outputName": "junit.xml"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@craco/craco": "^7.1.0",
     "coverbadge": "^0.5.5",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,11 @@
-import {render, screen} from "@testing-library/react";
-import App from "./App";
-import {municipalityFixture} from "./types/Municipality";
+import { ThemeProvider } from "@mui/material";
+import theme from "@styles/theme";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {municipalityPayloadFixture} from "./types/MunicipalityWithWeatherData";
-import {remove, save} from "./util/BrowserStorage";
-import theme from "./styles/theme";
-import {ThemeProvider} from "@mui/material";
-import React from "react";
+import { municipalityFixture } from "@type/Municipality";
+import { municipalityPayloadFixture } from "@type/MunicipalityWithWeatherData";
+import { remove, save } from "@util/BrowserStorage";
+import App from "./App";
 
 const mockMunicipalities = [municipalityFixture()];
 const mockMunicipalityPayload = municipalityPayloadFixture();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
+import { MunicipalityCard } from "@components/MunicipalityCard";
+import { MunicipalitySearchBar } from "@components/MunicipalitySearchBar";
+import { useBrowserStore } from "@hooks/UseBrowserStore";
 import { Container, Grid, Theme, useMediaQuery } from "@mui/material";
+import { Municipalities } from "@type/Municipalities";
+import { Municipality } from "@type/Municipality";
 import { useState } from "react";
-import { Municipalities } from "types/Municipalities";
-import { MunicipalityCard } from "./components/MunicipalityCard";
-import { MunicipalitySearchBar } from "./components/MunicipalitySearchBar";
-import { useBrowserStore } from "./hooks/UseBrowserStore";
-import { Municipality } from "./types/Municipality";
 
 function App() {
   const savedMunicipalities = useBrowserStore();

--- a/src/components/MunicipalityCard.test.tsx
+++ b/src/components/MunicipalityCard.test.tsx
@@ -1,14 +1,14 @@
-import {render, screen} from "@testing-library/react";
-import {MunicipalityCard} from "./MunicipalityCard";
-import {municipalityFixture} from "../types/Municipality";
+import { MunicipalityCard } from "@components/MunicipalityCard";
+import { ThemeProvider } from "@mui/material";
+import theme from "@styles/theme";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {get, remove} from "../util/BrowserStorage";
+import { municipalityFixture } from "@type/Municipality";
 import {
   municipalityPayloadFixture,
   MunicipalityWithWeatherData,
-} from "../types/MunicipalityWithWeatherData";
-import theme from "../styles/theme";
-import {ThemeProvider} from "@mui/material";
+} from "@type/MunicipalityWithWeatherData";
+import { get, remove } from "@util/BrowserStorage";
 
 const mockMunicipalityPayload = jest.fn();
 
@@ -17,12 +17,12 @@ jest.mock("../hooks/UseFetchMunicipalityWithWeatherData", () => ({
 }));
 
 async function addMunicipalityToFavorites(): Promise<void> {
-  const saveButton = screen.getByRole("button", {name: "Save"});
+  const saveButton = screen.getByRole("button", { name: "Save" });
   userEvent.click(saveButton);
 }
 
 async function removeMunicipalityFromFavorites(): Promise<void> {
-  const removeButton = await screen.findByRole("button", {name: "Remove"});
+  const removeButton = await screen.findByRole("button", { name: "Remove" });
   userEvent.click(removeButton);
 }
 
@@ -78,7 +78,7 @@ describe("Given a municipality card", () => {
 
   describe("when the municipality weather data has been loaded", () => {
     it("should display the weather data as the card content", () => {
-      const {data} = municipalityPayloadFixture();
+      const { data } = municipalityPayloadFixture();
 
       mockMunicipalityPayload.mockReturnValue({
         data: data,
@@ -140,10 +140,10 @@ describe("Given a municipality card", () => {
 
       await addMunicipalityToFavorites();
 
-      const removeButton = await screen.findByRole("button", {name: "Remove"});
+      const removeButton = await screen.findByRole("button", { name: "Remove" });
       expect(removeButton).toBeInTheDocument();
 
-      const saveButton = screen.queryByRole("button", {name: "Save"});
+      const saveButton = screen.queryByRole("button", { name: "Save" });
       expect(saveButton).not.toBeInTheDocument();
 
       expect(get(municipality.id)).toEqual(municipality);
@@ -160,10 +160,10 @@ describe("Given a municipality card", () => {
         await addMunicipalityToFavorites();
         await removeMunicipalityFromFavorites();
 
-        const saveButton = await screen.findByRole("button", {name: "Save"});
+        const saveButton = await screen.findByRole("button", { name: "Save" });
         expect(saveButton).toBeInTheDocument();
 
-        const removeButton = screen.queryByRole("button", {name: "Remove"});
+        const removeButton = screen.queryByRole("button", { name: "Remove" });
         expect(removeButton).not.toBeInTheDocument();
 
         expect(get(municipality.id)).toBeNull();

--- a/src/components/MunicipalityCard.tsx
+++ b/src/components/MunicipalityCard.tsx
@@ -1,3 +1,4 @@
+import { useFetchMunicipalityWithWeatherData } from "@hooks/UseFetchMunicipalityWithWeatherData";
 import {
   Air,
   Close,
@@ -20,14 +21,13 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-import { useState } from "react";
-import { useFetchMunicipalityWithWeatherData } from "../hooks/UseFetchMunicipalityWithWeatherData";
-import { Municipality } from "../types/Municipality";
+import { Municipality } from "@type/Municipality";
 import {
   MunicipalityPayload,
   MunicipalityWithWeatherData,
-} from "../types/MunicipalityWithWeatherData";
-import { get, remove, save } from "../util/BrowserStorage";
+} from "@type/MunicipalityWithWeatherData";
+import { get, remove, save } from "@util/BrowserStorage";
+import { useState } from "react";
 
 type MunicipalityCardProps = {
   municipality: Municipality;

--- a/src/components/MunicipalitySearchBar.test.tsx
+++ b/src/components/MunicipalitySearchBar.test.tsx
@@ -1,8 +1,8 @@
+import { MunicipalitySearchBar } from "@components/MunicipalitySearchBar";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Municipalities } from "types/Municipalities";
-import { municipalityFixture } from "../types/Municipality";
-import { MunicipalitySearchBar } from "./MunicipalitySearchBar";
+import { Municipalities } from "@type/Municipalities";
+import { municipalityFixture } from "@type/Municipality";
 
 const mockMunicipalities = jest.fn();
 

--- a/src/components/MunicipalitySearchBar.tsx
+++ b/src/components/MunicipalitySearchBar.tsx
@@ -1,7 +1,7 @@
+import { useFetchMunicipalities } from "@hooks/UseFetchMunicipalities";
 import { Autocomplete, TextField } from "@mui/material";
-import { Municipalities } from "types/Municipalities";
-import { useFetchMunicipalities } from "../hooks/UseFetchMunicipalities";
-import { Municipality } from "../types/Municipality";
+import { Municipalities } from "@type/Municipalities";
+import { Municipality } from "@type/Municipality";
 
 type MunicipalitySearchBarProps = {
   onChange: (municipality: Municipality | null) => void;

--- a/src/hooks/UseBrowserStore.test.ts
+++ b/src/hooks/UseBrowserStore.test.ts
@@ -1,7 +1,7 @@
-import {renderHook} from "@testing-library/react";
-import {useBrowserStore} from "./UseBrowserStore";
-import {remove, save} from "../util/BrowserStorage";
-import {municipalityFixture} from "../types/Municipality";
+import { useBrowserStore } from "@hooks/UseBrowserStore";
+import { renderHook } from "@testing-library/react";
+import { municipalityFixture } from "@type/Municipality";
+import { remove, save } from "@util/BrowserStorage";
 
 describe("Given the UseBrowserStore hook", () => {
   const municipality = municipalityFixture();
@@ -12,7 +12,7 @@ describe("Given the UseBrowserStore hook", () => {
 
   describe("when there are no municipalities stored in the browser local storage", () => {
     it("should return an empty list of municipalities", () => {
-      const {result} = renderHook(() => useBrowserStore());
+      const { result } = renderHook(() => useBrowserStore());
 
       expect(result.current.length).toBe(0);
     });
@@ -22,7 +22,7 @@ describe("Given the UseBrowserStore hook", () => {
     it("should return them", () => {
       save(municipality);
 
-      const {result} = renderHook(() => useBrowserStore());
+      const { result } = renderHook(() => useBrowserStore());
 
       expect(result.current.length).toBe(1);
     });
@@ -33,7 +33,7 @@ describe("Given the UseBrowserStore hook", () => {
       localStorage.setItem("hello", "world");
       save(municipality);
 
-      const {result} = renderHook(() => useBrowserStore());
+      const { result } = renderHook(() => useBrowserStore());
 
       expect(result.current.length).toBe(1);
     });

--- a/src/hooks/UseBrowserStore.ts
+++ b/src/hooks/UseBrowserStore.ts
@@ -1,6 +1,6 @@
-import { Municipalities } from "types/Municipalities";
-import { Municipality } from "types/Municipality";
-import { get, MUNICIPALITY_ID_FORMAT } from "../util/BrowserStorage";
+import { Municipalities } from "@type/Municipalities";
+import { Municipality } from "@type/Municipality";
+import { get, MUNICIPALITY_ID_FORMAT } from "@util/BrowserStorage";
 
 export function useBrowserStore(): Municipalities {
   const municipalities: Municipality[] = [];

--- a/src/hooks/UseFetchMunicipalities.test.ts
+++ b/src/hooks/UseFetchMunicipalities.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
+import { municipalityFixture } from "@type/Municipality";
 import useSWR from "swr";
-import { municipalityFixture } from "../types/Municipality";
 import { ExternalMunicipality, useFetchMunicipalities } from "./UseFetchMunicipalities";
 
 jest.mock("swr");

--- a/src/hooks/UseFetchMunicipalities.ts
+++ b/src/hooks/UseFetchMunicipalities.ts
@@ -1,5 +1,5 @@
+import { Municipality } from "@type/Municipality";
 import useSWR from "swr";
-import { Municipality } from "../types/Municipality";
 
 export type ExternalMunicipality = {
   NOMBRE: string;

--- a/src/hooks/UseFetchMunicipalityWithWeatherData.test.ts
+++ b/src/hooks/UseFetchMunicipalityWithWeatherData.test.ts
@@ -1,8 +1,8 @@
-import {Municipality, municipalityFixture} from "../types/Municipality";
+import { useFetchMunicipalityWithWeatherData } from "@hooks/UseFetchMunicipalityWithWeatherData";
+import { renderHook } from "@testing-library/react";
+import { Municipality, municipalityFixture } from "@type/Municipality";
+import { municipalityWithWeatherDataFixture } from "@type/MunicipalityWithWeatherData";
 import useSWR from "swr";
-import {renderHook} from "@testing-library/react";
-import {useFetchMunicipalityWithWeatherData} from "./UseFetchMunicipalityWithWeatherData";
-import {municipalityWithWeatherDataFixture} from "../types/MunicipalityWithWeatherData";
 
 jest.mock("swr");
 
@@ -38,7 +38,7 @@ describe("Given the UseFetchMunicipalityWithWeatherData hook", () => {
           error: new Error("Service unavailable"),
         });
 
-        const {result} = renderHook(() =>
+        const { result } = renderHook(() =>
           useFetchMunicipalityWithWeatherData(municipality)
         );
 
@@ -54,7 +54,7 @@ describe("Given the UseFetchMunicipalityWithWeatherData hook", () => {
         useSWR.mockReturnValueOnce({
           data: {
             temperatura_actual: "5",
-            temperaturas: {max: "10", min: "2"},
+            temperaturas: { max: "10", min: "2" },
             humedad: "47",
             viento: "30",
             lluvia: "5",
@@ -62,7 +62,7 @@ describe("Given the UseFetchMunicipalityWithWeatherData hook", () => {
           error: undefined,
         });
 
-        const {result} = renderHook(() =>
+        const { result } = renderHook(() =>
           useFetchMunicipalityWithWeatherData(municipality)
         );
 

--- a/src/hooks/UseFetchMunicipalityWithWeatherData.ts
+++ b/src/hooks/UseFetchMunicipalityWithWeatherData.ts
@@ -1,9 +1,9 @@
-import useSWR from "swr";
-import { Municipality } from "../types/Municipality";
+import { Municipality } from "@type/Municipality";
 import {
   MunicipalityPayload,
   MunicipalityWithWeatherData,
-} from "../types/MunicipalityWithWeatherData";
+} from "@type/MunicipalityWithWeatherData";
+import useSWR from "swr";
 
 const MUNICIPALITY_WEATHER_DATA_URL =
   "https://www.el-tiempo.net/api/json/v2/provincias/{provinceId}/municipios/{id}";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
 import { ThemeProvider } from "@mui/material";
+import theme from "@styles/theme";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import theme from "./styles/theme";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 

--- a/src/types/Municipalities.ts
+++ b/src/types/Municipalities.ts
@@ -1,4 +1,4 @@
-import { Municipality } from "./Municipality";
+import { Municipality } from "@type/Municipality";
 
 /**
  * Inspired in the Decorator design pattern, this class is a wrapper for an array of municipalities.

--- a/src/types/MunicipalityWithWeatherData.ts
+++ b/src/types/MunicipalityWithWeatherData.ts
@@ -1,4 +1,4 @@
-import { Municipality, municipalityFixture } from "./Municipality";
+import { Municipality, municipalityFixture } from "@type/Municipality";
 
 class Temperature {
   readonly actual!: string;

--- a/src/util/BrowserStorage.test.ts
+++ b/src/util/BrowserStorage.test.ts
@@ -1,5 +1,5 @@
-import {get, remove, save} from "./BrowserStorage";
-import {Municipality, municipalityFixture} from "../types/Municipality";
+import { Municipality, municipalityFixture } from "@type/Municipality";
+import { get, remove, save } from "@util/BrowserStorage";
 
 describe("Browser storage utils", () => {
   const municipality = municipalityFixture();

--- a/src/util/BrowserStorage.ts
+++ b/src/util/BrowserStorage.ts
@@ -1,4 +1,4 @@
-import { Municipality } from "../types/Municipality";
+import { Municipality } from "@type/Municipality";
 
 export const MUNICIPALITY_ID_FORMAT = /^\d{5}$/;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "target": "ES6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,13 +15,15 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@hooks/*": ["hooks/*"],
+      "@type/*": ["types/*"],
+      "@styles/*": ["styles/*"],
+      "@util/*": ["util/*"]
+    }
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist/**/*"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,7 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.24.7":
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz#5373c7bc8366b12a033b4be1ac13a206c6656aab"
   integrity sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==
@@ -108,7 +108,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.0":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.0":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz#a109bf9c3d58dfed83aaf42e85633c89f43a6253"
   integrity sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==
@@ -355,6 +355,16 @@
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -1157,6 +1167,19 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@craco/craco@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-7.1.0.tgz#12bd394c7f0334e214302e4d35a1768f68042fbb"
+  integrity sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==
+  dependencies:
+    autoprefixer "^10.4.12"
+    cosmiconfig "^7.0.1"
+    cosmiconfig-typescript-loader "^1.0.0"
+    cross-spawn "^7.0.3"
+    lodash "^4.17.21"
+    semver "^7.3.7"
+    webpack-merge "^5.8.0"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -3044,9 +3067,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "22.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.0.1.tgz#98e3ed275e511da5b2391bbcbc88caf2831baa1f"
-  integrity sha512-RVKWL+s4ax6syie/ev3FXFIs38mke4ZsCDPBcLF2Gu6MbQXKe9Fo9iU0EPUxDB1mDVvC0vCgkV3lKa2f6xIuHg==
+  version "22.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.0.2.tgz#9fb1a2b31970871e8bf696f0e8a40d2e6d2bd04e"
+  integrity sha512-yPL6DyFwY5PiMVEwymNeqUTKsDczQBJ/5T7W/46RwLU/VH+AA8aT5TZkvBviLKLbbm0hlfftEkGrNzfRk/fofQ==
   dependencies:
     undici-types "~6.11.1"
 
@@ -4083,7 +4106,7 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-autoprefixer@^10.4.13:
+autoprefixer@^10.4.12, autoprefixer@^10.4.13:
   version "10.4.19"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.19.tgz#ad25a856e82ee9d7898c59583c1afeb3fa65f89f"
   integrity sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==
@@ -4746,6 +4769,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone-response@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
@@ -4987,6 +5019,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cosmiconfig-typescript-loader@^1.0.0:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz#69c523f7e8c3d9f27f563d02bbeadaf2f27212d3"
+  integrity sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==
+  dependencies:
+    cosmiconfig "^7"
+    ts-node "^10.7.0"
+
 cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
@@ -4998,7 +5038,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7, cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
   integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
@@ -6921,6 +6961,11 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 flatted@^3.2.9:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
@@ -8025,6 +8070,13 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
+
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
@@ -8159,6 +8211,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 isomorphic-fetch@^2.2.1:
   version "2.2.1"
@@ -12373,6 +12430,13 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -13310,6 +13374,25 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-node@^10.7.0:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-toolbelt@^6.15.5:
   version "6.15.5"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
@@ -13923,6 +14006,15 @@ webpack-manifest-plugin@^4.0.2:
     tapable "^2.0.0"
     webpack-sources "^2.2.0"
 
+webpack-merge@^5.8.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz#a3ad5d773241e9c682803abf628d4cd62b8a4177"
+  integrity sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==
+  dependencies:
+    clone-deep "^4.0.1"
+    flat "^5.0.2"
+    wildcard "^2.0.0"
+
 webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -14106,6 +14198,11 @@ wide-align@^1.1.2:
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
+
+wildcard@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
+  integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
 word-wrap@^1.2.5, word-wrap@~1.2.3:
   version "1.2.5"


### PR DESCRIPTION
Changed imports to internal resources (e.g., components or hooks) to use path aliases (e.g., `@components`). Added CRACO as a test dependency to make it possible.